### PR TITLE
feat: add CLI support for SQLite and custom tracking URIs

### DIFF
--- a/tracking/README.md
+++ b/tracking/README.md
@@ -31,6 +31,8 @@ pip install mlflow scikit-learn pandas numpy matplotlib seaborn
 ```
 
 ### Run the Example
+
+#### **Basic Usage (File Store)**
 ```bash
 # Using entry point
 uv run mlflow-tracking-example
@@ -38,6 +40,39 @@ uv run mlflow-tracking-example
 # Or directly
 python tracking/simple_tracking_basic.py
 ```
+
+#### **SQLite Database Backend**
+```bash
+# Use SQLite database for tracking
+python tracking/simple_tracking_basic.py --backend sqlite --db-path ./mlflow.db
+
+# Custom database location
+python tracking/simple_tracking_basic.py --backend sqlite --db-path /path/to/my/experiments.db
+```
+
+#### **Custom Tracking URI**
+```bash
+# Direct SQLite URI
+python tracking/simple_tracking_basic.py --tracking-uri sqlite:///path/to/mlflow.db
+
+# Remote MLflow server
+python tracking/simple_tracking_basic.py --tracking-uri http://localhost:5000
+
+# Custom experiment name
+python tracking/simple_tracking_basic.py --experiment-name "my-custom-experiment"
+```
+
+#### **Command Line Options**
+```bash
+# View all available options
+python tracking/simple_tracking_basic.py --help
+```
+
+**Available Arguments:**
+- `--backend {file,sqlite}` - Backend store type (default: file)
+- `--db-path DB_PATH` - Path to SQLite database file (default: ./mlflow.db)
+- `--tracking-uri TRACKING_URI` - Custom MLflow tracking URI (overrides other options)
+- `--experiment-name EXPERIMENT_NAME` - MLflow experiment name (default: simple-house-prediction)
 
 ## 📊 What the Example Does
 
@@ -66,6 +101,46 @@ The `simple_tracking_basic.py` demonstrates the **complete MLflow workflow** in 
 ### **6. 🔮 Make Predictions**
 - Uses loaded model for inference on sample data
 - Shows end-to-end workflow completion
+
+## 🗄️ Backend Store Options
+
+### **File Store (Default)**
+- **Best for**: Development, local experiments, getting started
+- **Storage**: Local `./mlruns` directory
+- **Pros**: Simple, no setup required, version control friendly
+- **Cons**: Not suitable for team collaboration or production
+
+### **SQLite Database**
+- **Best for**: Local development with better query performance
+- **Storage**: Single SQLite database file
+- **Pros**: Better performance, SQL queries, atomic operations
+- **Cons**: Single-user, not suitable for concurrent access
+
+```bash
+# SQLite benefits
+python tracking/simple_tracking_basic.py --backend sqlite --db-path ./experiments.db
+```
+
+### **Remote Tracking Server**
+- **Best for**: Team collaboration, production deployments
+- **Storage**: Remote MLflow server with database backend
+- **Pros**: Multi-user, concurrent access, centralized tracking
+- **Cons**: Requires server setup and maintenance
+
+```bash
+# Connect to remote server
+python tracking/simple_tracking_basic.py --tracking-uri http://mlflow-server:5000
+```
+
+### **Backend Store Comparison**
+
+| Feature | File Store | SQLite | Remote Server |
+|---------|------------|---------|---------------|
+| Setup Complexity | ✅ None | ✅ Simple | ❌ Complex |
+| Performance | ⚠️ Moderate | ✅ Good | ✅ Excellent |
+| Multi-user | ❌ No | ❌ No | ✅ Yes |
+| Query Support | ❌ Limited | ✅ Full SQL | ✅ Full SQL |
+| Production Ready | ❌ No | ⚠️ Limited | ✅ Yes |
 
 ## 🤖 MLflow Autolog Benefits
 
@@ -191,12 +266,32 @@ data_gen = loader.load_module("data_generation")
 
 After running the example, explore results in the MLflow UI:
 
+### **File Store Backend**
 ```bash
-# Start MLflow UI
+# Start MLflow UI (default file store)
 mlflow ui
 
 # Visit in browser
 open http://localhost:5000
+```
+
+### **SQLite Backend**
+```bash
+# Start MLflow UI with SQLite database
+mlflow ui --backend-store-uri sqlite:///./mlflow.db
+
+# Or specify custom database path
+mlflow ui --backend-store-uri sqlite:///path/to/your/experiments.db
+
+# Visit in browser
+open http://localhost:5000
+```
+
+### **Remote Server**
+```bash
+# Connect to remote MLflow server
+# No local UI needed - access server directly
+open http://your-mlflow-server:5000
 ```
 
 ### In the MLflow UI you can:

--- a/tracking/simple_tracking_basic.py
+++ b/tracking/simple_tracking_basic.py
@@ -8,13 +8,20 @@ A minimal example showing the core MLflow workflow:
 4. Save the model
 5. Load the model
 6. Make inference
+
+Supports multiple backend stores via command line arguments:
+- File store (default): --backend file
+- SQLite store: --backend sqlite --db-path ./mlflow.db
+- Custom URI: --tracking-uri <uri>
 """
 
 import sys
+import argparse
 from pathlib import Path
 import mlflow
 import mlflow.sklearn
 from sklearn.ensemble import RandomForestRegressor
+
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import mean_squared_error, r2_score
 
@@ -25,16 +32,92 @@ sys.path.insert(0, str(utils_path))
 from utils.loader import load_mlflow_setup, load_data_generation
 
 
+def parse_arguments():
+    """Parse command line arguments for backend store configuration."""
+    parser = argparse.ArgumentParser(
+        description="Simple MLflow Tracking Example with configurable backend store",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Use default file store
+  python simple_tracking_basic.py
+  
+  # Use SQLite database
+  python simple_tracking_basic.py --backend sqlite --db-path ./mlflow.db
+  
+  # Use custom tracking URI
+  python simple_tracking_basic.py --tracking-uri sqlite:///path/to/mlflow.db
+  
+  # Use remote tracking server
+  python simple_tracking_basic.py --tracking-uri http://localhost:5000
+        """
+    )
+    
+    parser.add_argument(
+        '--backend', 
+        choices=['file', 'sqlite'], 
+        default='file',
+        help='Backend store type (default: file)'
+    )
+    
+    parser.add_argument(
+        '--db-path', 
+        type=str, 
+        default='./mlflow.db',
+        help='Path to SQLite database file (default: ./mlflow.db)'
+    )
+    
+    parser.add_argument(
+        '--tracking-uri', 
+        type=str,
+        help='Custom MLflow tracking URI (overrides --backend and --db-path)'
+    )
+    
+    parser.add_argument(
+        '--experiment-name', 
+        type=str, 
+        default='simple-house-prediction',
+        help='MLflow experiment name (default: simple-house-prediction)'
+    )
+    
+    return parser.parse_args()
+
+
+def get_tracking_uri(args):
+    """Generate tracking URI based on command line arguments."""
+    if args.tracking_uri:
+        return args.tracking_uri
+    
+    if args.backend == 'sqlite':
+        # Ensure the database path is absolute for SQLite URI
+        db_path = Path(args.db_path).resolve()
+        return f"sqlite:///{db_path}"
+    
+    # Default file store
+    return "file:./mlruns"
+
+
 def main():
     """Simple MLflow tracking workflow."""
+    # Parse command line arguments
+    args = parse_arguments()
+    
+    # Get tracking URI based on arguments
+    tracking_uri = get_tracking_uri(args)
+    
     print("=" * 40)
     print("Simple MLflow Tracking")
     print("=" * 40)
+    print(f"Backend: {args.backend}")
+    print(f"Tracking URI: {tracking_uri}")
+    print(f"Experiment: {args.experiment_name}")
+    print("=" * 40)
     
-    # 1. Setup MLflow
+    # 1. Setup MLflow with specified backend
     mlflow_setup = load_mlflow_setup()
     mlflow_setup.setup_mlflow_tracking(
-        experiment_name="simple-house-prediction",
+        tracking_uri=tracking_uri,
+        experiment_name=args.experiment_name,
         enable_autolog=True
     )
     
@@ -100,4 +183,6 @@ def main():
 
 
 if __name__ == "__main__":
+    # Ensure no active runs from previous sessions
+    mlflow.end_run()
     main()


### PR DESCRIPTION
- Add command line argument parsing with argparse
- Support --backend {file,sqlite} for backend store selection
- Add --db-path option for SQLite database location
- Support --tracking-uri for custom MLflow tracking servers
- Add --experiment-name option for custom experiment names
- Include comprehensive help text with usage examples
- Update README with detailed backend store documentation
- Add backend comparison table and MLflow UI instructions
- Test SQLite backend functionality successfully