### PR TITLE
refactor: clean up Spark LangChain integration files

### DIFF
--- a/spark/spark_langchain_multiple_mode.py
+++ b/spark/spark_langchain_multiple_mode.py
@@ -31,10 +31,9 @@ import random
 sys.path.append(str(Path(__file__).parent.parent / "utils"))
 
 import mlflow
-import mlflow.sklearn
 import mlflow.langchain
 from pyspark.sql import SparkSession
-from pyspark.sql.functions import col, lit, udf
+from pyspark.sql.functions import col, udf
 from pyspark.sql.types import StructType, StructField, StringType, IntegerType
 
 # LangChain imports with fallback
@@ -322,7 +321,7 @@ def main():
     experiment_id = mlflow_setup.setup_mlflow_tracking(
         tracking_uri="file:./mlruns",
         experiment_name=args.experiment_name,
-        enable_autolog=True  # Use autolog for any sklearn components
+        enable_autolog=True
     )
     
     # Enable MLflow LangChain autologging if using Ollama

--- a/spark/spark_langchain_ollama.py
+++ b/spark/spark_langchain_ollama.py
@@ -37,7 +37,7 @@ sys.path.append(str(Path(__file__).parent.parent / "utils"))
 import mlflow
 import mlflow.langchain
 from pyspark.sql import SparkSession
-from pyspark.sql.functions import col, lit, udf
+from pyspark.sql.functions import col, udf
 from pyspark.sql.types import StructType, StructField, StringType, IntegerType
 
 # LangChain imports for Ollama
@@ -172,7 +172,11 @@ def setup_ollama_llm(model_name: str = "llama3.2", base_url: str = "http://local
 
 
 def analyze_sentiment_with_ollama(text: str, llm) -> str:
-    """Analyze sentiment using Ollama via ChatOpenAI client."""
+    """Analyze sentiment using Ollama via ChatOpenAI client.
+    
+    Uses a recursive fallback pattern: if Ollama fails or returns unclear results,
+    falls back to rule-based keyword matching by calling itself with llm=None.
+    """
     
     if not llm:
         # Fallback rule-based analysis


### PR DESCRIPTION
 Add recursive fallback pattern documentation to analyze_sentiment_with_ollama()
- Remove unused imports: mlflow.sklearn and lit from pyspark.sql.functions  
- Remove misleading sklearn comment from enable_autolog parameter
- Improve code clarity and maintainability